### PR TITLE
NodeSelector, tolerations and affinity for ray operator in Ray Helm chart

### DIFF
--- a/helm/ray/chart/Chart.yaml
+++ b/helm/ray/chart/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deployments of Ray on Kubernetes.
 type: application
 
 # Chart version.
-version: 0.1.1
+version: 0.1.2
 
 # Ray version.
 appVersion: "latest"

--- a/helm/ray/chart/templates/operator_cluster_scoped.yaml
+++ b/helm/ray/chart/templates/operator_cluster_scoped.yaml
@@ -69,4 +69,13 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- .Values.nodeSelector | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- .Values.tolerations | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity: {{- .Values.affinity | toYaml | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/helm/ray/chart/templates/operator_namespaced.yaml
+++ b/helm/ray/chart/templates/operator_namespaced.yaml
@@ -70,4 +70,13 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- .Values.nodeSelector | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- .Values.tolerations | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity: {{- .Values.affinity | toYaml | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/helm/ray/chart/values.yaml
+++ b/helm/ray/chart/values.yaml
@@ -110,6 +110,26 @@ operatorNamespace: default
 # should carry matching Ray versions.
 operatorImage: syntho.azurecr.io/syntho-ray:latest-cpu
 
+nodeSelector: {}
+
+tolerations:
+# - key: nvidia.com/gpu
+#   operator: Exists
+#   effect: NoSchedule
+
+affinity:
+#  podAffinity:
+#    preferredDuringSchedulingIgnoredDuringExecution:
+#     - weight: 50
+#       podAffinityTerm:
+#         labelSelector:
+#           matchExpressions:
+#           - key: app
+#             operator: In
+#             values:
+#               - syntho
+#         topologyKey: "kubernetes.io/hostname"
+
 extraVolumes:
 # extraVolumes:
 #  - name: syntho-secret


### PR DESCRIPTION
Changes:

- NodeSelector, Tolerations and affinity added for Ray operators (cluster-scoped and namespace-scoped)
- Additional variables defined in the example file for operator pod scheduling (nodeselector, tolerations, affinity)