### PR TITLE
Resources adjustments, some url changes, probes fine-tuning, initContainers, declarativeness etc

### DIFF
--- a/helm/ray/templates/raycluster-storage.yaml
+++ b/helm/ray/templates/raycluster-storage.yaml
@@ -9,4 +9,11 @@ spec:
   resources:
     requests:
       storage: 20Gi
-  storageClassName: {{ .Values.storage.storageClassName | default "default" }}
+
+{{- if and (or (not .Values.storage.storageClassName) (eq .Values.storage.storageClassName "")) .Values.storage.pvLabelKey }}
+  selector:
+    matchLabels:
+      pv-label-key: {{ .Values.storage.pvLabelKey }}
+{{- else }}
+  storageClassName: {{ .Values.storage.storageClassName }}
+{{- end }}

--- a/helm/ray/templates/raycluster-storage.yaml
+++ b/helm/ray/templates/raycluster-storage.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
-  - ReadWriteMany
+  - {{ .Values.storage.accessMode | default "ReadWriteMany" }}
   resources:
     requests:
       storage: 20Gi

--- a/helm/ray/values.yaml
+++ b/helm/ray/values.yaml
@@ -226,8 +226,7 @@ fullnameOverride: "kuberay-operator"
 
 storage:
   pvLabelKey: # provide this if a manually crated PV is going to be used
-  storageClassName: standard
-  # accessMode: ReadWriteOnce
+  storageClassName: default
   accessMode: ReadWriteMany
 
 serviceAccount:

--- a/helm/ray/values.yaml
+++ b/helm/ray/values.yaml
@@ -1,7 +1,7 @@
 # Default values for kuberay-operator.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-SynthoLicense: key
+SynthoLicense: "<put-your-own-license>"
 
 clustername: ray-cluster
 
@@ -14,8 +14,8 @@ operatorImage:
   pullPolicy: IfNotPresent
 
 image:
-  repository: syntho.azurecr.io/syntho-ray
-  tag: 0.31.2-cpu
+  repository: rayproject/ray
+  tag: latest-py310-cpu-aarch64
   pullPolicy: IfNotPresent
 
 head:
@@ -69,12 +69,12 @@ head:
   # for further guidance.
   resources:
     limits:
-      cpu: "6"
+      cpu: "1000m"
       # To avoid out-of-memory issues, never allocate less than 2G memory for the Ray head.
-      memory: "32G"
+      memory: "4G"
     requests:
-      cpu: "6"
-      memory: "32G"
+      cpu: "500m"
+      memory: "2G"
   annotations: {}
   nodeSelector: {}
   tolerations: []
@@ -133,11 +133,11 @@ worker:
   # for further guidance.
   resources:
     limits:
-      cpu: "1"
-      memory: "1G"
+      cpu: "1000m"
+      memory: "4G"
     requests:
-      cpu: "1"
-      memory: "1G"
+      cpu: "500m"
+      memory: "2G"
   annotations: {}
   nodeSelector: {}
   tolerations: []
@@ -222,7 +222,8 @@ nameOverride: "kuberay"
 fullnameOverride: "kuberay-operator"
 
 storage:
-  storageClassName: default
+  storageClassName: standard
+  accessMode: ReadWriteOnce
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/helm/ray/values.yaml
+++ b/helm/ray/values.yaml
@@ -14,8 +14,11 @@ operatorImage:
   pullPolicy: IfNotPresent
 
 image:
-  repository: rayproject/ray
-  tag: latest-py310-cpu-aarch64
+  # replace them if it is being tested on ARM chip
+  # repository: rayproject/ray
+  # tag: latest-py310-cpu-aarch64
+  repository: syntho.azurecr.io/syntho-ray
+  tag: latest-cpu
   pullPolicy: IfNotPresent
 
 head:
@@ -222,8 +225,10 @@ nameOverride: "kuberay"
 fullnameOverride: "kuberay-operator"
 
 storage:
+  pvLabelKey: # provide this if a manually crated PV is going to be used
   storageClassName: standard
-  accessMode: ReadWriteOnce
+  # accessMode: ReadWriteOnce
+  accessMode: ReadWriteMany
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/helm/syntho-ui/templates/backend/backend-deployment.yaml
+++ b/helm/syntho-ui/templates/backend/backend-deployment.yaml
@@ -61,7 +61,7 @@ spec:
             - name: WORKERS
               value: {{quote .Values.backend.workers }}
             - name: EXTRA_ALLOWED_HOSTS
-              value: {{quote .Values.frontend_url }}
+              value: "{{ .Values.frontend_url }} {{ .Values.backend.name }}.syntho.svc.cluster.local"
           {{- if or $.Values.backend.env $.Values.backend.envSecrets }}
             {{- range $key, $value := $.Values.backend.env }}
             - name: {{ $key }}
@@ -83,11 +83,11 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              cpu: "2000m"
+              cpu: "1000m"
               ephemeral-storage: "2Gi"
               memory: "4Gi"
             requests:
-              cpu: "2000m"
+              cpu: "500m"
               ephemeral-storage: "2Gi"
               memory: "2Gi"
           readinessProbe:
@@ -97,8 +97,10 @@ spec:
               httpHeaders:
               - name: Host
                 value: {{ .Values.frontend_url }}
-            initialDelaySeconds: 10
-            periodSeconds: 60
+            initialDelaySeconds: 120
+            timeoutSeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
             successThreshold: 1
           livenessProbe:
             httpGet:
@@ -107,10 +109,11 @@ spec:
               httpHeaders:
               - name: Host
                 value: {{ .Values.frontend_url }}
-            initialDelaySeconds: 60
-            timeoutSeconds: 10
-            periodSeconds: 10
-            failureThreshold: 2
+            initialDelaySeconds: 240
+            timeoutSeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+            successThreshold: 1
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/syntho-ui/templates/backend/backend-service.yaml
+++ b/helm/syntho-ui/templates/backend/backend-service.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   ports:
     - name: backend-port
-      port: {{ .Values.backend.service.port }}
+      port: 80
       targetPort: {{ .Values.backend.service.port }}
   selector:
     app: {{ .Values.backend.name }}

--- a/helm/syntho-ui/templates/core/core-deployment.yaml
+++ b/helm/syntho-ui/templates/core/core-deployment.yaml
@@ -73,28 +73,29 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           resources:
             limits:
-              cpu: "2000m"
+              cpu: "1000m"
               ephemeral-storage: "3Gi"
               memory: "3Gi"
             requests:
-              cpu: "2000m"
+              cpu: "500m"
               ephemeral-storage: "3Gi"
               memory: "2Gi"
           readinessProbe:
             httpGet:
               path: /api/v1/status
               port: {{ .Values.core.port }}
-            initialDelaySeconds: 20
-            periodSeconds: 10
+            initialDelaySeconds: 120
+            periodSeconds: 30
             successThreshold: 1
+            failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /api/v1/status
               port: {{ .Values.core.port }}
-            initialDelaySeconds: 30
-            timeoutSeconds: 3
-            periodSeconds: 5
-            failureThreshold: 1
+            initialDelaySeconds: 240
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 3
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/syntho-ui/templates/dbs/database-data-1-persistentvolumeclaim.yaml
+++ b/helm/syntho-ui/templates/dbs/database-data-1-persistentvolumeclaim.yaml
@@ -11,5 +11,6 @@ spec:
   resources:
     requests:
       storage: 100Mi
+  storageClassName: {{ .Values.db.storageClassName | default "default" }}
 status: {}
 {{- end }}

--- a/helm/syntho-ui/templates/dbs/database-data-2-persistentvolumeclaim.yaml
+++ b/helm/syntho-ui/templates/dbs/database-data-2-persistentvolumeclaim.yaml
@@ -12,5 +12,6 @@ spec:
   resources:
     requests:
       storage: 100Mi
+  storageClassName: {{ .Values.db.storageClassName | default "default" }}
 status: {}
 {{- end }}

--- a/helm/syntho-ui/templates/frontend/frontend-deployment.yaml
+++ b/helm/syntho-ui/templates/frontend/frontend-deployment.yaml
@@ -19,6 +19,17 @@ spec:
       labels:
         app: {{ .Values.frontend.name }}
     spec:
+      initContainers:
+        - name: wait-for-backend-service
+          image: busybox
+          command:
+            - 'sh'
+            - '-c'
+            - |
+              until wget -q --spider --server-response --header "Host: {{ .Values.frontend_url }}" "http://{{ .Values.backend.name }}.syntho.svc.cluster.local/api/docs/" 2>&1 | grep -q "HTTP/1.1 200 OK"; do
+                echo "Waiting for the backend service to be ready..."
+                sleep 1
+              done
       containers:
         - image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
           env:
@@ -27,11 +38,11 @@ spec:
             - name: PORT
               value: {{quote .Values.frontend.port}}
             - name: OPEN_API_URL
-              value: {{ .Values.frontend_protocol }}://{{ .Values.frontend_url }}{{ .Values.frontend_path }}/api/playground/?format=openapi
+              value: {{ .Values.backend.name }}.syntho.svc.cluster.local/api/playground/?format=openapi
             - name: NEXT_PUBLIC_BACKEND_HOST
-              value: {{ .Values.frontend_url }}{{ .Values.frontend_path }}
+              value: {{ .Values.backend.name }}.syntho.svc.cluster.local
             - name: NEXT_PUBLIC_BACKEND_PROTOCOL
-              value: {{ .Values.frontend_protocol }}
+              value: http
             - name: NEXT_PUBLIC_BACKEND_WS_PROTOCOL
               value: wss
             - name: NEXT_PUBLIC_FRONTEND_HOST
@@ -41,7 +52,11 @@ spec:
             - name: FRONTEND_PATH
               value: {{ .Values.frontend_path }}
             - name: BACKEND_HOST
-              value: {{ .Values.backend.name }}:{{ .Values.backend.port }}
+              value: {{ .Values.backend.name }}.syntho.svc.cluster.local
+          {{- if .Values.frontend.ingress.tls.selfSignedSSLCertificate }}
+            - name: _JAVA_OPTIONS
+              value: "-Dio.swagger.parser.util.RemoteUrl.trustAll=true -Dio.swagger.v3.parser.util.RemoteUrl.trustAll=true"
+          {{- end }}
           {{- if or $.Values.frontend.env $.Values.frontend.envSecrets }}
             {{- range $key, $value := $.Values.frontend.env }}
             - name: {{ $key }}
@@ -56,33 +71,28 @@ spec:
             {{- end }}
           {{- end }}
           volumeMounts:
-            {{- toYaml .Values.frontend.volumeMounts | default "" | nindent 12 }} 
+            {{- toYaml .Values.frontend.volumeMounts | default "" | nindent 12 }}
           name: {{ .Values.frontend.name }}
           ports:
             - name: frontend-port
               containerPort: {{ .Values.frontend.service.port }}
           resources:
             limits:
-              cpu: "4000m"
+              cpu: "2000m"
               ephemeral-storage: "3Gi"
               memory: "3Gi"
             requests:
-              cpu: "2000m"
+              cpu: "500m"
               ephemeral-storage: "3Gi"
               memory: "3Gi"
           readinessProbe:
             tcpSocket:
               port: 3000
-            initialDelaySeconds: 60
-            periodSeconds: 10
-          #livenessProbe:
-          #  httpGet:
-          #    path: /login
-          #    port: frontend-port
-          #  initialDelaySeconds: 50
-          #  timeoutSeconds: 10
-          #  periodSeconds: 10
-          #  failureThreshold: 1
+            initialDelaySeconds: 240
+            timeoutSeconds: 30
+            periodSeconds: 60
+            failureThreshold: 3
+            successThreshold: 1
           imagePullPolicy: Always
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/syntho-ui/templates/frontend/frontend-deployment.yaml
+++ b/helm/syntho-ui/templates/frontend/frontend-deployment.yaml
@@ -53,10 +53,6 @@ spec:
               value: {{ .Values.frontend_path }}
             - name: BACKEND_HOST
               value: {{ .Values.backend.name }}.syntho.svc.cluster.local
-          {{- if .Values.frontend.ingress.tls.selfSignedSSLCertificate }}
-            - name: _JAVA_OPTIONS
-              value: "-Dio.swagger.parser.util.RemoteUrl.trustAll=true -Dio.swagger.v3.parser.util.RemoteUrl.trustAll=true"
-          {{- end }}
           {{- if or $.Values.frontend.env $.Values.frontend.envSecrets }}
             {{- range $key, $value := $.Values.frontend.env }}
             - name: {{ $key }}

--- a/helm/syntho-ui/templates/frontend/frontend-ingress.yaml
+++ b/helm/syntho-ui/templates/frontend/frontend-ingress.yaml
@@ -28,9 +28,9 @@ spec:
   {{- if and .Values.frontend.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.frontend.ingress.className }}
   {{- end }}
-  {{- if .Values.frontend.ingress.tls }}
+  {{- if .Values.frontend.ingress.tls.enabled }}
   tls:
-    {{- range .Values.frontend.ingress.tls }}
+    {{- range .Values.frontend.ingress.conf.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}

--- a/helm/syntho-ui/values.yaml
+++ b/helm/syntho-ui/values.yaml
@@ -12,7 +12,7 @@ core:
   replicaCount: 1
   image:
     repository: syntho.azurecr.io/syntho-core-api
-    tag: 0.45.1
+    tag: latest
   name: core
   service:
     port: 8080
@@ -40,7 +40,7 @@ backend:
   replicaCount: 1
   image:
     repository: syntho.azurecr.io/syntho-core-backend
-    tag: 0.30.0
+    tag: latest
   name: backend
   port: 8000
   workers: 1
@@ -71,7 +71,7 @@ frontend:
   name: frontend
   image:
     repository: syntho.azurecr.io/syntho-core-frontend
-    tag: 1.26.0
+    tag: latest
   port: 3000
   service:
     port: 3000
@@ -101,20 +101,19 @@ frontend:
           - syntho.company.com
           secretName: frontend-tls
       enabled: false
-      selfSignedSSLCertificate: false
 
 db:
   image:
     repository: syntho.azurecr.io/postgres
     tag: latest
-  storageClassName: standard
+  storageClassName: default
 
 redis:
   replicaCount: 1
   image:
     repository: redis
     tag: 7.2-rc2
-  storageClassName: standard
+  storageClassName: default
 
 imagePullSecrets:
   - name: syntho-cr-secret

--- a/helm/syntho-ui/values.yaml
+++ b/helm/syntho-ui/values.yaml
@@ -2,17 +2,17 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-frontend_path: 
+frontend_path:
 frontend_url: syntho.company.com
-frontend_protocol: https
+frontend_protocol: http
 
-SynthoLicense: 
+SynthoLicense: "<put-your-own-license>"
 
 core:
   replicaCount: 1
   image:
     repository: syntho.azurecr.io/syntho-core-api
-    tag: latest
+    tag: 0.45.1
   name: core
   service:
     port: 8080
@@ -20,7 +20,7 @@ core:
   volumes: []
   volumeMounts: []
   database_enabled: true
-  celery_args: ['-A', 'app.celery', 'worker', '--loglevel=info', '--concurrency=4', '--max-memory-per-child=50000']
+  celery_args: ['-A', 'app.celery', 'worker', '--loglevel=info', '--concurrency=1', '--max-memory-per-child=50000']
   db:
     username: postgres
     password: postgres
@@ -28,23 +28,23 @@ core:
     host: postgres
     port: 5432
   port: 8080
-  secret_key: abcd12412
+  secret_key: ZzXj2az_fnnM59mviJc0hmU_jhcdIVaI51dbEkuiXLk=
   redis:
     host: redis-svc
     port: 6379
     db: 1
-  ray_address: ray-cluster-head-svc
-  workers: 2
+  ray_address: ray-cluster-head-svc.syntho.svc.cluster.local
+  workers: 1
 
 backend:
   replicaCount: 1
   image:
     repository: syntho.azurecr.io/syntho-core-backend
-    tag: latest
+    tag: 0.30.0
   name: backend
   port: 8000
-  workers: 4
-  secret_key: secret-key-change-this-into-something-much-more-safe
+  workers: 1
+  secret_key: ix!57KPgpcyu!&2mMn69pB#R8zLhxLXAexnNoF!XZvqHB9G4JG%QLmFnE8Rx^3bMF#EG7rAxnWK*7LzKWF8S62qbTC
   redis:
     host: redis-svc
     port: 6379
@@ -71,7 +71,7 @@ frontend:
   name: frontend
   image:
     repository: syntho.azurecr.io/syntho-core-frontend
-    tag: latest
+    tag: 1.26.0
   port: 3000
   service:
     port: 3000
@@ -94,26 +94,30 @@ frontend:
         paths:
           - path: /
             pathType: Prefix
-    
+
     tls:
-      - hosts:
-        - syntho.company.com
-        secretName: frontend-tls
+      conf:
+        - hosts:
+          - syntho.company.com
+          secretName: frontend-tls
+      enabled: false
+      selfSignedSSLCertificate: false
 
 db:
   image:
     repository: syntho.azurecr.io/postgres
     tag: latest
+  storageClassName: standard
 
 redis:
   replicaCount: 1
   image:
     repository: redis
     tag: 7.2-rc2
-  storageClassName: default
+  storageClassName: standard
 
-imagePullSecrets: 
-  - name: <synthoImageSecret>
+imagePullSecrets:
+  - name: syntho-cr-secret
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
### TL;DR
Main idea is to prepare the charts for the next step with minimal change: more declarative approach (avoiding commenting/uncommenting things, letting user deploy the stack with minimum effort).

### Things that have been done in this PR
- Letting user to choose a RWO access moded storages (in case there is a single node k8s setup - convenient for default setup as well)
- minimum resource usages are adjusted after trying multiple deployment attempts
- backend's ALLOWED_HOSTS are adjusted for in-cluster access
- liveness/readinessProbs are adjusted for better startup
- frontend startup depends on backend's readiness (an initContainer setup is added for frontend)
- uncommenting/commentings things in values are no longer exists, instead used a more declarative approach

PS. Please feel free to provide feedback on this as the next steps are blocked until a decision is made on this.