### PR TITLE
backend worker cpu limit fine tuning

### DIFF
--- a/helm/syntho-ui/templates/backend/backend-deployment.yaml
+++ b/helm/syntho-ui/templates/backend/backend-deployment.yaml
@@ -208,7 +208,7 @@ spec:
         imagePullPolicy: Always
         resources:
             limits:
-              cpu: "500m"
+              cpu: "1000m"
               ephemeral-storage: "2Gi"
               memory: "500Mi"
             requests:


### PR DESCRIPTION
I measured it during its cold startup period, and it sometimes consumes more CPU than 500m and the pod is killed. This is fixing the behavior.