### PR TITLE
This change is required to make ray work properly on ARM archs (at least for me to test properly on my local)

### DIFF
--- a/helm/config/images-arm.env
+++ b/helm/config/images-arm.env
@@ -1,4 +1,4 @@
 RAY_IMAGE_IMG_REPO=rayproject/ray
-RAY_IMAGE_IMG_TAG=latest-py310-cpu-aarch64
+RAY_IMAGE_IMG_TAG=latest-py311-cpu-aarch64
 POSTGRES_IMG_REPO=postgres
 POSTGRES_IMG_VER=14.5


### PR DESCRIPTION
with the recent changes on Syntho side, ray head image i snow using py11 for amd archs. But since I am also testing things on my local and to make my life a bit easy, I also updated ray cpu arch image's version.