### PR TITLE
core worker cpu limits got increased a bit, cuz it hits more than the existing one when running

### DIFF
--- a/helm/syntho-ui/templates/core/core-worker-pod.yaml
+++ b/helm/syntho-ui/templates/core/core-worker-pod.yaml
@@ -76,16 +76,16 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           resources:
             limits:
-              cpu: "1000m"
+              cpu: "1250m"
               ephemeral-storage: "3Gi"
-              memory: "750Mi"
+              memory: "1000Mi"
             requests:
               cpu: "1000m"
               ephemeral-storage: "3Gi"
               memory: "750Mi"
           readinessProbe:
-            initialDelaySeconds: 30
-            periodSeconds: 10
+            initialDelaySeconds: 120
+            periodSeconds: 30
             timeoutSeconds: 10
             exec:
               command:
@@ -93,8 +93,8 @@ spec:
               - "-c"
               - "celery -b redis://{{ .Values.core.redis.host}}:{{ .Values.core.redis.port }}/{{ .Values.core.redis.db }} inspect ping -d celery@$HOSTNAME"
           livenessProbe:
-            initialDelaySeconds: 30
-            periodSeconds: 10
+            initialDelaySeconds: 90
+            periodSeconds: 30
             timeoutSeconds: 10
             exec:
               command:


### PR DESCRIPTION
fine tunings for a minimum resource requirements;

- recent core-worker image's startup time is longer than the previous versions
- this cause a long cold startup
- but the readiness and livenessProbe wasn't really enough for  it
- I tried to adjust by increasing bit by bit and this is the final version for pod to start properly before going to crashlookbackoff loop